### PR TITLE
Build only Netbird CLI path

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,9 @@ jobs:
           gettext git java-propose-classpath libelf-dev libncurses5-dev \
           libncursesw5-dev libssl-dev python python2.7-dev python3 unzip wget \
           python3-distutils python3-setuptools python3-dev rsync subversion \
-          swig time xsltproc zlib1g-dev
+          swig time xsltproc zlib1g-dev libgtk-3-dev libappindicator3-dev \
+          libayatana-appindicator3-dev libgl1-mesa-dev xorg-dev gcc-mingw-w64-x86-64
+
       - name: Install OpenWrt SDK
         run: |
           wget -O openwrt-sdk.tar.xz ${{ matrix.target.sdk }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,8 +36,7 @@ jobs:
           gettext git java-propose-classpath libelf-dev libncurses5-dev \
           libncursesw5-dev libssl-dev python python2.7-dev python3 unzip wget \
           python3-distutils python3-setuptools python3-dev rsync subversion \
-          swig time xsltproc zlib1g-dev libgtk-3-dev libappindicator3-dev \
-          libayatana-appindicator3-dev libgl1-mesa-dev xorg-dev gcc-mingw-w64-x86-64
+          swig time xsltproc zlib1g-dev
 
       - name: Install OpenWrt SDK
         run: |

--- a/netbird/Makefile
+++ b/netbird/Makefile
@@ -13,7 +13,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/netbirdio/netbird
-GO_PKG_BUILD_PKG:=github.com/netbirdio/netbird/client/...
+GO_PKG_BUILD_PKG:=github.com/netbirdio/netbird/client
 GO_PKG_LDFLAGS:=-s -w
 GO_PKG_LDFLAGS_X:=main.Version=v$(PKG_VERSION)
 


### PR DESCRIPTION
As a new Netbird UI client was introduced we shouldn't build the whole directory recursively. 

The UI client has some unnecessary dependencies that makes the build fail

fixes #1