### PR TITLE
Update CI to add support for arm_cortex-a15

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,8 @@ jobs:
             sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/rockchip/armv8/openwrt-sdk-22.03.3-rockchip-armv8_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
           - arch: "arm_cortex-a9"
             sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/bcm53xx/generic/openwrt-sdk-22.03.3-bcm53xx-generic_gcc-11.2.0_musl_eabi.Linux-x86_64.tar.xz"
+          - arch: "arm_cortex-a15"
+            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/ipq806x/generic/openwrt-sdk-22.03.3-ipq806x-generic_gcc-11.2.0_musl_eabi.Linux-x86_64.tar.xz"
           - arch: "aarch64_cortex-a53"
             sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/bcm27xx/bcm2710/openwrt-sdk-22.03.3-bcm27xx-bcm2710_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
           - arch: "aarch64_cortex-a72"


### PR DESCRIPTION
This adds in support to the CI for arm_cortex-a15 (also known as ipq806x). My router uses this arch and I would benefit from first party support so I do not need to maintain a fork of this repository.