### PR TITLE
Fix CI compilation errors

### DIFF
--- a/.github/feeds.conf.default
+++ b/.github/feeds.conf.default
@@ -1,0 +1,1 @@
+src-git packages https://github.com/openwrt/packages.git^002cea57c04dc8cc606b49d2f3d6902cfbac75d8

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,28 +11,29 @@ jobs:
     name: Build - ${{ matrix.target.arch }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         target:
           - arch: "aarch64_generic"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/rockchip/armv8/openwrt-sdk-22.03.3-rockchip-armv8_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/rockchip/armv8/openwrt-sdk-22.03.5-rockchip-armv8_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
           - arch: "arm_cortex-a9"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/bcm53xx/generic/openwrt-sdk-22.03.3-bcm53xx-generic_gcc-11.2.0_musl_eabi.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/bcm53xx/generic/openwrt-sdk-22.03.5-bcm53xx-generic_gcc-11.2.0_musl_eabi.Linux-x86_64.tar.xz"
           - arch: "arm_cortex-a15"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/ipq806x/generic/openwrt-sdk-22.03.3-ipq806x-generic_gcc-11.2.0_musl_eabi.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/ipq806x/generic/openwrt-sdk-22.03.5-ipq806x-generic_gcc-11.2.0_musl_eabi.Linux-x86_64.tar.xz"
           - arch: "aarch64_cortex-a53"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/bcm27xx/bcm2710/openwrt-sdk-22.03.3-bcm27xx-bcm2710_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/bcm27xx/bcm2710/openwrt-sdk-22.03.5-bcm27xx-bcm2710_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
           - arch: "aarch64_cortex-a72"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/bcm27xx/bcm2711/openwrt-sdk-22.03.3-bcm27xx-bcm2711_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/bcm27xx/bcm2711/openwrt-sdk-22.03.5-bcm27xx-bcm2711_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
           - arch: "arm_cortex-a7_neon-vfpv4"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/ipq40xx/generic/openwrt-sdk-22.03.3-ipq40xx-generic_gcc-11.2.0_musl_eabi.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/ipq40xx/generic/openwrt-sdk-22.03.5-ipq40xx-generic_gcc-11.2.0_musl_eabi.Linux-x86_64.tar.xz"
           - arch: "x86_64"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/x86/64/openwrt-sdk-22.03.3-x86-64_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/x86/64/openwrt-sdk-22.03.5-x86-64_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
           - arch: "i386_pentium4"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/x86/generic/openwrt-sdk-22.03.3-x86-generic_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/x86/generic/openwrt-sdk-22.03.5-x86-generic_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
           - arch: "mips_74kc"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/ath79/generic/openwrt-sdk-22.03.3-ath79-generic_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/ath79/generic/openwrt-sdk-22.03.5-ath79-generic_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
           - arch: "mipsel_24kc"
-            sdk: "https://downloads.openwrt.org/releases/22.03.3/targets/ramips/mt7621/openwrt-sdk-22.03.3-ramips-mt7621_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
+            sdk: "https://downloads.openwrt.org/releases/22.03.5/targets/ramips/mt7621/openwrt-sdk-22.03.5-ramips-mt7621_gcc-11.2.0_musl.Linux-x86_64.tar.xz"
     steps:
       - uses: actions/checkout@v2
       - name: Install build requirements

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,6 +50,7 @@ jobs:
           wget -O openwrt-sdk.tar.xz ${{ matrix.target.sdk }}
           xz -q -d openwrt-sdk.tar.xz && tar -xvf openwrt-sdk.tar
           mv -f openwrt-sdk-* openwrt-sdk
+          mv -f .github/feeds.conf.default openwrt-sdk/feeds.conf.default
       - name: Build Package
         run: |
           echo "src-link netbird $GITHUB_WORKSPACE" > openwrt-sdk/feeds.conf
@@ -63,6 +64,7 @@ jobs:
           cat feeds.conf
 
           ./scripts/feeds update -a > /dev/null
+          rm -rf ./feeds/packages/net/netbird
           make defconfig
 
           ./scripts/feeds install -d y -f -a

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,7 @@ jobs:
           cd openwrt-sdk
 
           git clone https://github.com/kuoruan/openwrt-upx.git package/upx
+          git -C package/upx checkout 2c2ee0d696ea6084bee893a2861a7ed0729728ed
 
           cat feeds.conf.default >> feeds.conf
           cat feeds.conf


### PR DESCRIPTION
1. golang 版本更新到 1.20.4，使用 openwrt sdk v23.05.0-rc1 的 packages 源
2. upx 版本回退到 v2022-10-20

fixes: #64
